### PR TITLE
ci: bootstrap GitHub Actions on default branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,27 @@
+name: Android CI
+
+on:
+  push:
+    branches: [master, stocked-revamp]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew assembleDebug
+
+      - name: Unit tests
+        run: ./gradlew testDebugUnitTest


### PR DESCRIPTION
Actions never fired for #11/#12 because the repo has no workflow on the default branch — GitHub doesn't initialize Actions until one lands on master.

**Heads-up:** the build job will be RED on this PR — master is still the 2018 code (Gradle 4.6 wants JDK 8, runner has 21). That failure is the whole point of the migration; checks go green from #11 onward, where the toolchain is modern.

Merge despite the red check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)